### PR TITLE
Api restructure

### DIFF
--- a/CovidTrackr.xcodeproj/project.pbxproj
+++ b/CovidTrackr.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		100122E529F757B0001CCE86 /* WMCountry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100122E429F757B0001CCE86 /* WMCountry.swift */; };
 		1010CFBE29A815D200D53ECE /*  ModalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1010CFBD29A815D200D53ECE /*  ModalViewModel.swift */; };
 		1010CFC029A8160300D53ECE /* CountryTimeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1010CFBF29A8160300D53ECE /* CountryTimeline.swift */; };
 		106D015629851B9300BBB03E /* MapboxMaps in Frameworks */ = {isa = PBXBuildFile; productRef = 106D015529851B9300BBB03E /* MapboxMaps */; };
@@ -31,6 +32,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		100122E429F757B0001CCE86 /* WMCountry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WMCountry.swift; sourceTree = "<group>"; };
 		1010CFBD29A815D200D53ECE /*  ModalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = " ModalViewModel.swift"; sourceTree = "<group>"; };
 		1010CFBF29A8160300D53ECE /* CountryTimeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryTimeline.swift; sourceTree = "<group>"; };
 		106D015729851BB800BBB03E /* WorldMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldMapView.swift; sourceTree = "<group>"; };
@@ -128,6 +130,7 @@
 				1010CFBF29A8160300D53ECE /* CountryTimeline.swift */,
 				106D016E2989193000BBB03E /* Worldometers.swift */,
 				1099284F29784E6700089FDA /* Timeline.swift */,
+				100122E429F757B0001CCE86 /* WMCountry.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -257,6 +260,7 @@
 				106D015829851BB800BBB03E /* WorldMapView.swift in Sources */,
 				10F672D5297FDE1C00E72C83 /* ModalView.swift in Sources */,
 				106D016F2989193100BBB03E /* Worldometers.swift in Sources */,
+				100122E529F757B0001CCE86 /* WMCountry.swift in Sources */,
 				1099284729779B1F00089FDA /* CountryData.swift in Sources */,
 				1010CFC029A8160300D53ECE /* CountryTimeline.swift in Sources */,
 				1099283529777AA100089FDA /* CovidTrackrApp.swift in Sources */,

--- a/CovidTrackr/APIService/Models/WMCountry.swift
+++ b/CovidTrackr/APIService/Models/WMCountry.swift
@@ -1,0 +1,23 @@
+//
+//  WMCountry.swift
+//  CovidTrackr
+//
+//  Created by Amron B on 4/6/23.
+//
+
+import Foundation
+
+public struct WMCountry: Decodable, Hashable, Identifiable {
+    public static func == (lhs: WMCountry, rhs: WMCountry) -> Bool {
+        lhs.country == rhs.country
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(country)
+    }
+    public let id: UUID = UUID()
+    public let updated: String?
+    public let country: String?
+    public let cases: Int?
+    public let deaths: Int?
+    public let countryInfo: CountryInfo?
+}

--- a/CovidTrackr/APIService/Models/Worldometers.swift
+++ b/CovidTrackr/APIService/Models/Worldometers.swift
@@ -9,6 +9,8 @@ import Foundation
 
 public struct Worldometers: Decodable {
     public let country: String?
+    public let cases: Int?
+    public let deaths: Int?
     public let countryInfo: CountryInfo?
     public let continent: String?
     public let population: Int?
@@ -17,12 +19,16 @@ public struct Worldometers: Decodable {
     
     public init(
         country: String?,
+        cases: Int?,
+        deaths: Int?,
         countryInfo: CountryInfo?,
         continent: String?,
         population: Int?,
         tests: Int?,
         updated: Int?){
         self.country = country
+        self.cases = cases
+        self.deaths = deaths
         self.countryInfo = countryInfo
         self.continent = continent
         self.population = population

--- a/CovidTrackr/View Models/ ModalViewModel.swift
+++ b/CovidTrackr/View Models/ ModalViewModel.swift
@@ -21,7 +21,7 @@ class ModalViewModel: ObservableObject {
         isLoading = true
         
         // Build url for API request
-        let formattedName = Utils.transformQueryParam(query: self.country.name)
+        let formattedName = Utils.transformQueryParam(query: self.country.info!.iso3!)
         let url = URL(string: "https://disease.sh/v3/covid-19/historical/\(formattedName)?lastdays=all")!
         
         // Send request and wait for response
@@ -34,7 +34,7 @@ class ModalViewModel: ObservableObject {
                     self.isLoading = false
                 }
             case .failure(let error):
-                print("Error loading JHUCSSE timeline for \(self.country)")
+                print("Error loading JHUCSSE timeline for \(self.country.name)")
                 print(error.localizedDescription)
             }
         }

--- a/CovidTrackr/View Models/DashboardViewModel.swift
+++ b/CovidTrackr/View Models/DashboardViewModel.swift
@@ -31,45 +31,29 @@ class DashboardViewModel: ObservableObject {
     func normalizeData(){
         var countryDict = [String:Country]()
         
-        // Merge JHUCSSE data
-        for jhuCountry in countryData {
-            let name = jhuCountry.country!
-            let stats = jhuCountry.stats!
-            
-            // Check if country is in dictionary, or create new
-            let country = countryDict[name] ?? Country(
-                name: name,
-                stats: stats
-            )
-            
-            countryDict[name] = country
-        }
-        
         // Merge WM data
         for wmCountry in worldometers {
             
-            var name = ""
-            if let jhuName = wmNamesMap[wmCountry.country!] {
-                name = jhuName
-            }else{
-                name = wmCountry.country!
-            }
-            
+            let name = wmCountry.country!
+            let cases = wmCountry.cases!
+            let deaths = wmCountry.deaths!
             let info = wmCountry.countryInfo!
             let continent = wmCountry.continent!
             let population = wmCountry.population!
             let tests = wmCountry.tests!
             
-            // Proceed only if there is corresponding JHUCountry data in the dictionary
-            if var country = countryDict[name] {
-                country.info = info
-                country.continent = continent
-                country.population = population
-                country.tests = tests
-                
-                // Update dictionary
-                countryDict[name] = country
-            }
+            // Check if country is in dictionary, or create new
+            let country = Country(
+                name: name,
+                continent: continent,
+                population: population,
+                tests: tests,
+                info: info,
+                stats: CovidStats(confirmed: cases, deaths: deaths)
+            )
+            
+            countryDict[name] = country
+
         }
         
         // Update countries as normalized data

--- a/CovidTrackr/View Models/DashboardViewModel.swift
+++ b/CovidTrackr/View Models/DashboardViewModel.swift
@@ -21,7 +21,6 @@ class DashboardViewModel: ObservableObject {
     }
     
     init(){
-        self.fetchCountryData()
         self.fetchGlobalTimeline()
         self.fetchWorldometers()
         self.normalizeData()
@@ -180,19 +179,7 @@ class DashboardViewModel: ObservableObject {
         }
     }
     
-    // Makes an API fetch to update countryData data
-    func fetchCountryData() {
-        let response = APIService.fetchDataSync(for: URL(string: "https://disease.sh/v3/covid-19/jhucsse")!) as Result<[CountryData], Error>
-        
-        switch response {
-        case .success(let data):
-            self.countryData = self.filterMultipleProvinces(data: data)
-        case .failure(let error):
-            print("Error loading JHUCSSE country (all) data")
-            print(error)
-            
-        }
-    }
+
     
     // Returns the top five countries sorted by cases or deaths
     func getTopFiveCountries(sortBy: SortBy) -> [CountryData]?{

--- a/CovidTrackr/Views/WorldMapView.swift
+++ b/CovidTrackr/Views/WorldMapView.swift
@@ -296,10 +296,10 @@ class MapboxViewController: UIViewController {
         var colorValue: Double = 0.0
         var expressionBody: String = ""
         var colorRGB: String = ""
-        let max_cases = 10500000
-        let startColor: Color = Color(red: 1, green: 1, blue: 1)
+        let max_cases = 60000000
+        let startColor: Color = Color(red: 0.857, green: 0.9176, blue: 0.937)
         var curColor: Color
-        let endColor: Color = Color(red: 0.03922, green: 0.1176, blue: 0.8627)
+        let endColor: Color = Color(red: 0.035, green: 0.2627, blue: 0.6509)
         // Convert the range of data values (countries) to a suitable color
         for country in viewModel.countries {
             // Calculate percentage of max cases


### PR DESCRIPTION
JHUCSSE recently announced that they are no longer tracking daily covid data, so the API calls being made to [disease.sh](http://disease.sh/) need to be restructured. This pull request contains changes made to the codebase in order to accommodate the switch from JHUCSSE to Worldometers — making  CovidTrackr reliant on Worldometers for all covid data parameters besides the historical timelines, which is still available from JHUCSSE for dates until March 10, 2023.

